### PR TITLE
Support parts and non-Dart files

### DIFF
--- a/lib/src/find_libraries.dart
+++ b/lib/src/find_libraries.dart
@@ -29,8 +29,9 @@ Future<Iterable<ClassElement>> findClassElements({
   );
 
   // TODO: Allow the starting point to be customized on the command line
-  final dartFiles =
-      Directory(makePackageSubPath('lib')).listSync(recursive: true);
+  final dartFiles = Directory(makePackageSubPath('lib'))
+      .listSync(recursive: true)
+      .where((file) => path.extension(file.path) == '.dart');
 
   final collector = ClassElementCollector(
     exportOnly: exportOnly,

--- a/lib/src/find_libraries.dart
+++ b/lib/src/find_libraries.dart
@@ -40,9 +40,10 @@ Future<Iterable<ClassElement>> findClassElements({
     final filePath = path.normalize(path.absolute(file.path));
     final context = contextCollection.contextFor(filePath);
 
-    final libraryResult =
-        await context.currentSession.getResolvedLibrary(filePath);
-    libraryResult.element.accept(collector);
+    final unitResult = await context.currentSession.getResolvedUnit(filePath);
+    if (!unitResult.isPart) {
+      unitResult.libraryElement.accept(collector);
+    }
   }
 
   return collector.classElements;

--- a/test/fixtures/simple/lib/src/internal.dart
+++ b/test/fixtures/simple/lib/src/internal.dart
@@ -1,1 +1,3 @@
+part 'part.dart';
+
 class InternalClass {}

--- a/test/fixtures/simple/lib/src/non_dart_file.txt
+++ b/test/fixtures/simple/lib/src/non_dart_file.txt
@@ -1,0 +1,1 @@
+This tests that non-dart files are filtered out.

--- a/test/fixtures/simple/lib/src/part.dart
+++ b/test/fixtures/simple/lib/src/part.dart
@@ -1,0 +1,3 @@
+part of 'internal.dart';
+
+class InternalClassInPart {}

--- a/test/functional/success_test.dart
+++ b/test/functional/success_test.dart
@@ -9,6 +9,7 @@ void main() {
       expect(result.exitCode, 0);
       expect(result.stdout, contains('ExternalClass'));
       expect(result.stdout, contains('InternalClass'));
+      expect(result.stdout, contains('InternalClassInPart'));
     });
 
     test('should ignore excluded classes', () {


### PR DESCRIPTION
When running in a large project, I hit some errors caused by
- trying to resolve the context for `.DS_STORE` 
- trying to get the library declared in part files

These changes filter out non-Dart files and skip trying to get the library for part files.

After these changes, it worked like a charm!

Side note, this is a seriously awesome package, thanks for building it!!! ❤️ 