### PR TITLE
Add regression test for blank namespaces

### DIFF
--- a/test/functional/export_test.dart
+++ b/test/functional/export_test.dart
@@ -27,8 +27,6 @@ void main() {
         '-p',
         'test/fixtures/exports/',
       ]);
-      print(result.stdout);
-      print(result.stderr);
       expect(result.exitCode, 0);
       expect(result.stdout, contains('PathExportedClass'));
       expect(result.stdout, isNot(contains('PathHiddenClass')));

--- a/test/functional/success_test.dart
+++ b/test/functional/success_test.dart
@@ -1,3 +1,4 @@
+import 'package:dcdg/src/constants.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -15,6 +16,14 @@ void main() {
       expect(result.stdout, contains('_PrivateInternalPrivate'));
       expect(result.stdout, contains('PublicPartInternalPartPublic'));
       expect(result.stdout, contains('_PrivatePartInternalPartPrivate'));
+    });
+
+    test('should not yield empty namespaces', () {
+      final result = runWith(['-p', 'test/fixtures/simple/']);
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains(namespaceSeparator));
+      expect(result.stdout,
+          isNot(contains(namespaceSeparator + namespaceSeparator)));
     });
 
     test('should search a subdirectory', () {


### PR DESCRIPTION
This fixes https://github.com/glesica/dcdg.dart/issues/6. Adds a regression test for the empty separator issue I'd noticed previously.