### PR TITLE
Add --has-a and --is-a filters

### DIFF
--- a/bin/dcdg.dart
+++ b/bin/dcdg.dart
@@ -38,7 +38,9 @@ Future<Null> main(Iterable<String> arguments) async {
     excludePrivateFields: config.excludePrivateFields,
     excludePrivateMethods: config.excludePrivateMethods,
     excludes: config.excludeExpressions,
+    hasA: config.hasAExpressions,
     includes: config.includeExpressions,
+    isA: config.isAExpressions,
   );
 
   if (config.outputPath == '') {

--- a/lib/src/build_diagram.dart
+++ b/lib/src/build_diagram.dart
@@ -12,7 +12,9 @@ void buildDiagram({
   bool excludePrivateFields,
   bool excludePrivateMethods,
   Iterable<RegExp> excludes,
+  Iterable<RegExp> hasA,
   Iterable<RegExp> includes,
+  Iterable<RegExp> isA,
 }) {
   final visitor = DiagramVisitor(
     onField: builder.addField,
@@ -23,7 +25,9 @@ void buildDiagram({
     excludePrivateFields: excludePrivateMethods,
     excludePrivateMethods: excludePrivateMethods,
     excludes: excludes,
+    hasA: hasA,
     includes: includes,
+    isA: isA,
   );
 
   for (final element in classElements) {

--- a/lib/src/command_line.dart
+++ b/lib/src/command_line.dart
@@ -5,8 +5,10 @@ const builderOption = 'builder';
 const excludeOption = 'exclude';
 const excludePrivateOption = 'exclude-private';
 const exportedOnlyOption = 'exported-only';
+const hasAOption = 'has-a';
 const helpOption = 'help';
 const includeOption = 'include';
+const isAOption = 'is-a';
 const outputPathOption = 'output';
 const packagePathOption = 'package';
 const searchPathOption = 'search-path';
@@ -34,6 +36,18 @@ final argParser = ArgParser(usageLineLength: 80)
     exportedOnlyOption,
     help: 'Include only classes exported from the Dart package',
     negatable: false,
+  )
+  ..addMultiOption(
+    hasAOption,
+    help:
+        'Include only classes with a has-a relationship to any of the named classes',
+    valueHelp: 'CLASS',
+  )
+  ..addMultiOption(
+    isAOption,
+    help:
+        'Include only classes with an is-a relationship to any of the named classes',
+    valueHelp: 'CLASS',
   )
   ..addFlag(
     helpOption,
@@ -79,6 +93,9 @@ $usage
 
 Available builders:
   * ${availableBuilders().join('\n  * ')}
+
+The --$includeOption, --$excludeOption, --$hasAOption, and --$isAOption
+options accept regular expressions.
 
 Note: If both excludes and includes are supplied, types that are in
 both lists will be removed from the includes list and then the

--- a/lib/src/configuration.dart
+++ b/lib/src/configuration.dart
@@ -21,7 +21,11 @@ abstract class Configuration {
 
   bool get excludePrivateMethods;
 
+  Iterable<RegExp> get hasAExpressions;
+
   Iterable<RegExp> get includeExpressions;
+
+  Iterable<RegExp> get isAExpressions;
 
   String get outputPath;
 
@@ -47,6 +51,11 @@ abstract class Configuration {
     final includeExpressions =
         (results[includeOption] as Iterable<String>).map((s) => RegExp(s));
 
+    final hasAExpressions =
+        (results[hasAOption] as Iterable<String>).map((s) => RegExp(s));
+    final isAExpressions =
+        (results[isAOption] as Iterable<String>).map((s) => RegExp(s));
+
     return ConfigurationImpl(
       builder: getBuilder(results[builderOption]),
       builderName: results[builderOption],
@@ -55,7 +64,9 @@ abstract class Configuration {
       excludePrivateFields: excludePrivateFields,
       excludePrivateMethods: excludePrivateMethods,
       exportedOnly: results[exportedOnlyOption],
+      hasAExpressions: hasAExpressions,
       includeExpressions: includeExpressions,
+      isAExpressions: isAExpressions,
       outputPath: results[outputPathOption],
       packagePath: results[packagePathOption],
       searchPath: results[searchPathOption],
@@ -92,7 +103,13 @@ class ConfigurationImpl implements Configuration {
   final bool exportedOnly;
 
   @override
+  Iterable<RegExp> hasAExpressions;
+
+  @override
   final Iterable<RegExp> includeExpressions;
+
+  @override
+  Iterable<RegExp> isAExpressions;
 
   @override
   final String outputPath;
@@ -114,7 +131,9 @@ class ConfigurationImpl implements Configuration {
     @required this.excludePrivateFields,
     @required this.excludePrivateMethods,
     @required this.exportedOnly,
+    @required this.hasAExpressions,
     @required this.includeExpressions,
+    @required this.isAExpressions,
     @required this.outputPath,
     @required this.packagePath,
     @required this.searchPath,


### PR DESCRIPTION
These are multi-options, so they can be provided more than once and the values passed with be OR'd. If both filters are specified then their sets of values are AND'd. So, for example, if you were to pass `--has-a bool` and `--is-a Foo`, you would get classes that both have a `bool` field and inherit from the class `Foo`.