### PR TITLE
Fix is-a include bug

### DIFF
--- a/lib/src/diagram_visitor.dart
+++ b/lib/src/diagram_visitor.dart
@@ -227,12 +227,17 @@ class DiagramVisitor extends RecursiveElementVisitor<void> {
     // TODO: Apply more regex filtering?
     if (!_excludeIsA) {
       final superType = element.supertype;
+      final superElement = superType?.element;
+
       final superIsObject = superType?.isDartCoreObject == true;
-      final isPrivate = superType?.element.isPrivate == true;
+      final superIsPrivate = superType?.element.isPrivate == true;
+      final superIsIncluded =
+          (superElement != null) && shouldInclude(superElement);
+
       if (superType != null &&
           !superIsObject &&
-          !(_excludePrivateClasses && isPrivate) &&
-          !shouldIncludeClass(element)) {
+          !(_excludePrivateClasses && superIsPrivate) &&
+          superIsIncluded) {
         _onSuperType(superType);
       }
 

--- a/test/fixtures/inheritance/lib/classes.dart
+++ b/test/fixtures/inheritance/lib/classes.dart
@@ -1,3 +1,5 @@
+import 'package:simple_fixture/external.dart';
+
 abstract class Extended {}
 
 abstract class MixedIn {}
@@ -9,3 +11,5 @@ class ClassExtend extends Extended {}
 class ClassMixIn with MixedIn {}
 
 class ClassImplement implements Implemented {}
+
+class ExternalExtends extends PublicExternalPublic {}

--- a/test/fixtures/inheritance/pubspec.lock
+++ b/test/fixtures/inheritance/pubspec.lock
@@ -120,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  simple_fixture:
+    dependency: "direct main"
+    description:
+      path: "../simple"
+      relative: true
+    source: path
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:

--- a/test/fixtures/inheritance/pubspec.yaml
+++ b/test/fixtures/inheritance/pubspec.yaml
@@ -2,6 +2,9 @@ name: inheritance_fixture
 description: A test fixture with inheritance
 environment:
   sdk: '>=2.12.0 <3.0.0'
+dependencies:
+  simple_fixture:
+    path: ../simple/
 dev_dependencies:
   dcdg:
     path: ../../../

--- a/test/functional/success_test.dart
+++ b/test/functional/success_test.dart
@@ -57,5 +57,16 @@ void main() {
       expect(result.stdout, contains('Sub'));
       expect(result.stdout, isNot(contains('NonSub')));
     });
+
+    test('should follow external packages', () {
+      final result = runWith(
+        [],
+        'test/fixtures/inheritance',
+      );
+      expect(result.stderr, '');
+      expect(result.exitCode, 0);
+      expect(result.stdout,
+          matches(r'.*PublicExternalPublic <|-- .*ExternalExtends'));
+    });
   });
 }

--- a/test/functional/utils.dart
+++ b/test/functional/utils.dart
@@ -10,11 +10,27 @@ void pubGetFixtures() {
   }
 
   Directory('test/fixtures/').listSync().whereType<Directory>().forEach((d) {
-    if (!d
-        .listSync()
-        .whereType<File>()
-        .any((f) => f.path.endsWith('${path.separator}pubspec.yaml'))) {
+    final files = d.listSync().whereType<File>();
+
+    // Skip the directory if it isn't a valid package.
+    if (!files.any((f) => f.path.endsWith('${path.separator}pubspec.yaml'))) {
       return;
+    }
+
+    // Try to short circuit if the lock file is up-to-date.
+    // This shaves about 2 minutes off the time to run the full test suite,
+    // or about 40%.
+    if (files.any((f) => f.path.endsWith('${path.separator}pubspec.lock'))) {
+      final yaml = files
+          .firstWhere((f) => f.path.endsWith('${path.separator}pubspec.yaml'));
+      final lock = files
+          .firstWhere((f) => f.path.endsWith('${path.separator}pubspec.lock'));
+
+      final yamlMod = yaml.lastModifiedSync();
+      final lockMod = lock.lastModifiedSync();
+      if (lockMod.isAfter(yamlMod)) {
+        return;
+      }
     }
 
     final result =


### PR DESCRIPTION
I noticed at least one bug in the include / exclude code. This should resolve it.

This also speeds up the tests pretty substantially by only running `pub get` if the pubspec has actually changed.