### PR TITLE
Avoid duplicates on parts

### DIFF
--- a/lib/src/find_class_elements.dart
+++ b/lib/src/find_class_elements.dart
@@ -47,7 +47,10 @@ Future<Iterable<ClassElement>> findClassElements({
 
     final unitResult = await context.currentSession.getResolvedUnit(filePath);
     if (unitResult is ResolvedUnitResult) {
-      unitResult.libraryElement.accept(collector);
+      // Skip parts files to avoid duplication.
+      if (!unitResult.isPart) {
+        unitResult.libraryElement.accept(collector);
+      }
     }
   }
 

--- a/test/fixtures/bindir/pubspec.lock
+++ b/test/fixtures/bindir/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "3.1.1"
+    version: "4.0.0"
   file:
     dependency: transitive
     description:

--- a/test/fixtures/inheritance/pubspec.lock
+++ b/test/fixtures/inheritance/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "3.1.1"
+    version: "4.0.0"
   file:
     dependency: transitive
     description:

--- a/test/fixtures/simple/pubspec.lock
+++ b/test/fixtures/simple/pubspec.lock
@@ -70,7 +70,7 @@ packages:
       path: "../../.."
       relative: true
     source: path
-    version: "3.1.1"
+    version: "4.0.0"
   file:
     dependency: transitive
     description:

--- a/test/functional/parts_test.dart
+++ b/test/functional/parts_test.dart
@@ -1,0 +1,33 @@
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+void main() {
+  setUpAll(() {
+    pubGetFixtures();
+  });
+
+  group('dcdg tool (parts cases)', () {
+    test('should not duplicate classes in files with parts', () {
+      final result = runWith(
+        [],
+        'test/fixtures/simple/',
+      );
+      expect(result.stderr, '');
+      expect(result.exitCode, 0);
+
+      final out = result.stdout as String;
+      for (final className in const [
+        'PublicInternalPublic',
+        'PublicPartInternalPartPublic',
+        '_PrivatePartInternalPartPrivate',
+        '_PrivateInternalPrivate',
+      ]) {
+        final first = out.indexOf(className);
+        final last = out.lastIndexOf(className);
+        expect(first, isNot(-1));
+        expect(first, equals(last), reason: '$className is duplicated');
+      }
+    });
+  });
+}

--- a/tool/check.sh
+++ b/tool/check.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 dart pub get
-dart run test -j 1 $@
+dart run test -j 1 "$@"
 

--- a/tool/format.sh
+++ b/tool/format.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dartfmt -w --fix --set-exit-if-changed .
+dart format --fix --set-exit-if-changed .


### PR DESCRIPTION
This fixes #50. The problem was just that classes are scanned file-by-file but when the analyzer parses a parts file it actually results in the whole parts structure being returned.

I also updated some tooling stuff that was outdated.